### PR TITLE
getOrElse is inappropriate

### DIFF
--- a/src/main/scala/com/abhi/Hangman.scala
+++ b/src/main/scala/com/abhi/Hangman.scala
@@ -37,7 +37,7 @@ object Hangman extends App {
         IO.sync(scala.util.Random.nextInt(max))
     val chooseWord: IO[IOException, String] = for {
         rand <- nextInt(Dictionary.length)
-    } yield Dictionary.lift(rand).getOrElse("Bug in the program!")
+    } yield Dictionary(rand)
     def gameLoop(state: State) : IO[IOException, State] = {
         for {
             guess <- getChoice


### PR DESCRIPTION
Thank you for capturing  the details from the presentation by John De Goes. 

I noticed a surprising piece of code (that might have been in the original presentation).
``yield Dictionary.lift(rand).getOrElse("Bug in the program!")``

The user visible consequence if this fallback is ever used is rather unfortunate since the string contains values that cannot be entered via the UI. The user is forced to enter 10 values and only then will they see this error message. This is obviously no more than an irritation in the context of this problem but people are likely to use this code as an exemplar for a real problem. 

By inspection, the index into Dictionary will never fail. The code thus be simply
``yield Dictionary(rand)``

If the index into Dictionary could fail, then there would be two cases to consider.

### Failure in the code
This is the case implied by the current code, that might arise if the range for random was incorrectly specified. Such a failure would be a non recoverable Error (in the Java language sense) and falls outside the scope of ZIO error representation.
We would want the code to fail fast in this situation and not attempt to proceed any further.
Consider a canary release, where such a program error should trigger an immediate rollback.

### Failure due to context outside of the code
In this case, the error is not pure and would need to be reflected in the ZIO error or value type.
The latter would require that the value be an Either, Try, etc.





